### PR TITLE
Add Mexican and US flag links below Walmart logo

### DIFF
--- a/wallmart
+++ b/wallmart
@@ -73,6 +73,28 @@
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
   }
 
+  /* Estilos para las banderas debajo del logo de Walmart */
+  .flag-links {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+  }
+
+  .flag-links a {
+    display: inline-block;
+    aspect-ratio: auto;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .flag-links img {
+    width: 30px;
+    height: auto;
+    border-radius: 0;
+  }
+
   /* Estilo para pantallas pequeñas */
   @media (max-width: 767px) {
     .grid-container {
@@ -103,6 +125,14 @@
       <a href="https://super.walmart.com.mx/search?q=Grileros" target="_blank" class="bg-walmart">
         <img src="https://cdn.shopify.com/s/files/1/0017/0885/1236/files/wallmart-grileros.webp?v=1749532989" alt="Comprar Grileros en Walmart">
       </a>
+      <div class="flag-links">
+        <a href="https://www.walmart.com.mx" target="_blank">
+          <img src="https://flagcdn.com/mx.svg" alt="Walmart México">
+        </a>
+        <a href="https://www.walmart.com" target="_blank">
+          <img src="https://flagcdn.com/us.svg" alt="Walmart USA">
+        </a>
+      </div>
     </div>
   </section>
 </div>


### PR DESCRIPTION
## Summary
- Add flag section under Walmart logo with separate links for Mexico and USA
- Style flag links to appear centered beneath the Walmart brand circle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fe547d0832f88cb9be8d9912e3b